### PR TITLE
Adds valuesetcodes endpoint

### DIFF
--- a/Fabric.Terminology.API/DependencyInjection/ServicesRequestComposition.cs
+++ b/Fabric.Terminology.API/DependencyInjection/ServicesRequestComposition.cs
@@ -17,6 +17,7 @@
             container.Register<Lazy<ClientTermContext>>((c, p) => c.Resolve<ClientTermContextFactory>().CreateLazy());
             container.Register<IValueSetService, SqlValueSetService>().AsSingleton();
             container.Register<IValueSetSummaryService, SqlValueSetSummaryService>().AsSingleton();
+            container.Register<IValueSetCodeService, SqlValueSetCodeService>().AsSingleton();
             container.Register<IClientTermValueSetService, SqlClientTermValueSetService>().AsSingleton();
             container.Register<ICodeSystemService, SqlCodeSystemService>().AsSingleton();
             container.Register<ICodeSystemCodeService, SqlCodeSystemCodeService>().AsSingleton();

--- a/Fabric.Terminology.API/Extensions.Models.cs
+++ b/Fabric.Terminology.API/Extensions.Models.cs
@@ -46,7 +46,10 @@
             return apiModel;
         }
 
-        public static PagedCollection<ValueSetItemApiModel> ToValueSetApiModelPage<T>(this PagedCollection<T> items, IReadOnlyCollection<Guid> codeSystemGuids, Func<T, IReadOnlyCollection<Guid>, ValueSetItemApiModel> mapper)
+        public static PagedCollection<ValueSetItemApiModel> ToValueSetApiModelPage<T>(
+            this PagedCollection<T> items,
+            IReadOnlyCollection<Guid> codeSystemGuids,
+            Func<T, IReadOnlyCollection<Guid>, ValueSetItemApiModel> mapper)
             where T : IValueSetSummary
         {
             return new PagedCollection<ValueSetItemApiModel>
@@ -55,6 +58,18 @@
                 TotalItems = items.TotalItems,
                 TotalPages = items.TotalPages,
                 Values = items.Values.Select(vsi => mapper(vsi, codeSystemGuids)).ToList()
+            };
+        }
+
+        public static PagedCollection<ValueSetCodeApiModel> ToValueSetCodeApiModelPage(
+            this PagedCollection<IValueSetCode> items)
+        {
+            return new PagedCollection<ValueSetCodeApiModel>
+            {
+                PagerSettings = items.PagerSettings,
+                TotalItems = items.TotalItems,
+                TotalPages = items.TotalPages,
+                Values = items.Values.Select(Mapper.Map<ValueSetCodeApiModel>).ToList()
             };
         }
 

--- a/Fabric.Terminology.API/MetaData/TagsFactory.cs
+++ b/Fabric.Terminology.API/MetaData/TagsFactory.cs
@@ -10,8 +10,17 @@
         {
             return new Tag
             {
-                Description = "Operations related to Shared Terminology Value Sets",
+                Description = "Operations related to Shared Terminology value sets",
                 Name = $"{TerminologyVersion.Route}/valuesets/"
+            };
+        }
+
+        public static Tag GetValueSetCodeTag()
+        {
+            return new Tag
+            {
+                Description = "Operations related to Shared Terminology value set codes",
+                Name = $"{TerminologyVersion.Route}/valuesetcodes/"
             };
         }
 

--- a/Fabric.Terminology.API/Modules/CodeSystemMetadataModule.cs
+++ b/Fabric.Terminology.API/Modules/CodeSystemMetadataModule.cs
@@ -30,7 +30,7 @@
                 "Gets a collection of all available code systems",
                 new[]
                 {
-                    new HttpResponseMetadata<CodeSystemApiModel> { Code = 200, Message = "OK" },
+                    new HttpResponseMetadata<IEnumerable<CodeSystemApiModel>> { Code = 200, Message = "OK" },
                     new HttpResponseMetadata { Code = 500, Message = "Internal Server Error" }
                 },
                 new Parameter[] { },

--- a/Fabric.Terminology.API/Modules/ValueSetCodeMetadataModule.cs
+++ b/Fabric.Terminology.API/Modules/ValueSetCodeMetadataModule.cs
@@ -1,0 +1,79 @@
+﻿namespace Fabric.Terminology.API.Modules
+{
+    using System.Collections.Generic;
+
+    using Fabric.Terminology.API.MetaData;
+    using Fabric.Terminology.API.Models;
+    using Fabric.Terminology.Domain.Models;
+    using Fabric.Terminology.SqlServer.Configuration;
+
+    using Nancy.Swagger;
+    using Nancy.Swagger.Modules;
+    using Nancy.Swagger.Services;
+    using Nancy.Swagger.Services.RouteUtils;
+
+    public class ValueSetCodeMetadataModule : SwaggerMetadataModule
+    {
+        public ValueSetCodeMetadataModule(
+            ISwaggerModelCatalog modelCatalog,
+            ISwaggerTagCatalog tagCatalog,
+            TerminologySqlSettings settings)
+            : base(modelCatalog, tagCatalog)
+        {
+            modelCatalog.AddModel<PagedCollection<ValueSetCodeApiModel>>();
+
+            this.RouteDescriber.DescribeRouteWithParams(
+                "GetAllValueSetCodesPaged",
+                "Returns a paged list of value set codes",
+                "Gets a paged collection of value set codes",
+                new[]
+                {
+                    new HttpResponseMetadata<PagedCollection<ValueSetCodeApiModel>> { Code = 200, Message = "OK" },
+                    new HttpResponseMetadata { Code = 500, Message = "Internal Server Error" }
+                },
+                new[]
+                {
+                    ParameterFactory.GetSkip(),
+                    ParameterFactory.GetTop(settings.DefaultItemsPerPage),
+                    ParameterFactory.GetCodeSystemGuidsArray()
+                },
+                new[] { TagsFactory.GetValueSetCodeTag() });
+
+            this.RouteDescriber.DescribeRouteWithParams(
+                "GetValueSetCodes",
+                "Returns a list of value set codes for a given a CodeGuid",
+                "Gets a list of value set codes for a given a CodeGuid",
+                new[]
+                {
+                    new HttpResponseMetadata<IEnumerable<ValueSetCodeApiModel>> { Code = 200, Message = "OK" },
+                    new HttpResponseMetadata { Code = 500, Message = "Internal Server Error" }
+                },
+                new[]
+                {
+                    ParameterFactory.GetCodeGuid()
+                },
+                new[]
+                {
+                    TagsFactory.GetValueSetCodeTag()
+                });
+
+            this.RouteDescriber.DescribeRouteWithParams(
+                "GetValueSetCodePagedByValueSet",
+                "Returns a paged list of value set codes",
+                "Gets a paged collection of value set codes",
+                new[]
+                {
+                    new HttpResponseMetadata<PagedCollection<ValueSetCodeApiModel>> { Code = 200, Message = "OK" },
+                    new HttpResponseMetadata { Code = 500, Message = "Internal Server Error" }
+                },
+                new[]
+                {
+                    ParameterFactory.GetValueSetGuid(),
+                    ParameterFactory.GetSkip(),
+                    ParameterFactory.GetTop(settings.DefaultItemsPerPage),
+                    ParameterFactory.GetCodeSystemGuidsArray()
+                },
+                new[] { TagsFactory.GetValueSetCodeTag() });
+        }
+    }
+}

--- a/Fabric.Terminology.API/Modules/ValueSetCodeModule.cs
+++ b/Fabric.Terminology.API/Modules/ValueSetCodeModule.cs
@@ -1,0 +1,86 @@
+﻿namespace Fabric.Terminology.API.Modules
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using AutoMapper;
+
+    using Fabric.Terminology.API.Configuration;
+    using Fabric.Terminology.API.Models;
+    using Fabric.Terminology.Domain.Services;
+
+    using Nancy;
+
+    using Serilog;
+
+    public sealed class ValueSetCodeModule : TerminologyModule<ValueSetCodeApiModel>
+    {
+        private readonly IValueSetCodeService valueSetCodeService;
+
+        public ValueSetCodeModule(
+            IValueSetCodeService valueSetCodeService,
+            IAppConfiguration config,
+            ILogger logger)
+            : base($"/{TerminologyVersion.Route}/valuesetcodes", config, logger)
+        {
+            this.valueSetCodeService = valueSetCodeService;
+
+            this.Get("/", _ => this.GetAllValueSetCodePage(), null, "GetAllValueSetCodesPaged");
+
+            this.Get("/{codeGuid}", parameters => this.GetValueSetCodes(parameters.codeGuid), null, "GetValueSetCodes");
+
+            this.Get("/valueset/{valueSetGuid}", parameters => this.GetValueSetCodePage(parameters.valueSetGuid), null, "GetValueSetCodePagedByValueSet");
+        }
+
+        private object GetValueSetCodes(Guid codeGuid)
+        {
+            try
+            {
+                return this.valueSetCodeService.GetValueSetCodesByCodeGuid(codeGuid)
+                    .Select(Mapper.Map<ValueSetCodeApiModel>);
+            }
+            catch (Exception ex)
+            {
+                this.Logger.Error(ex, ex.Message);
+                return this.CreateFailureResponse(
+                    "Failed to retrieve value set codes for Guid " + codeGuid.ToString(),
+                    HttpStatusCode.InternalServerError);
+            }
+        }
+
+        private async Task<object> GetAllValueSetCodePage()
+        {
+            try
+            {
+                var pagerSettings = this.GetPagerSettings();
+                var codeSystemGuids = this.GetCodeSystems();
+                return (await this.valueSetCodeService.GetValueSetCodesAsync(pagerSettings, codeSystemGuids)).ToValueSetCodeApiModelPage();
+            }
+            catch (Exception ex)
+            {
+                this.Logger.Error(ex, ex.Message);
+                return this.CreateFailureResponse(
+                    "Failed to retrieve the page of value set codes",
+                    HttpStatusCode.InternalServerError);
+            }
+        }
+
+        private async Task<object> GetValueSetCodePage(Guid valueSetGuid)
+        {
+            try
+            {
+                var pagerSettings = this.GetPagerSettings();
+                var codeSystemGuids = this.GetCodeSystems();
+                return (await this.valueSetCodeService.GetValueSetCodesAsync(valueSetGuid, pagerSettings, codeSystemGuids)).ToValueSetCodeApiModelPage();
+            }
+            catch (Exception ex)
+            {
+                this.Logger.Error(ex, ex.Message);
+                return this.CreateFailureResponse(
+                    "Failed to retrieve the page of value set codes",
+                    HttpStatusCode.InternalServerError);
+            }
+        }
+    }
+}

--- a/Fabric.Terminology.Domain/Services/IValueSetCodeService.cs
+++ b/Fabric.Terminology.Domain/Services/IValueSetCodeService.cs
@@ -1,0 +1,34 @@
+﻿namespace Fabric.Terminology.Domain.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    using Fabric.Terminology.Domain.Models;
+
+    public interface IValueSetCodeService
+    {
+        IReadOnlyCollection<IValueSetCode> GetValueSetCodes(Guid valueSetGuid);
+
+        /// <summary>
+        ///     Get a collection of value set codes by the codeGuid.
+        /// </summary>
+        /// <remarks>
+        ///     Useful for determining which value sets to which a <see cref="ICodeSystemCode" /> is associated.
+        /// </remarks>
+        IReadOnlyCollection<IValueSetCode> GetValueSetCodesByCodeGuid(Guid codeGuid);
+
+        Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(Guid valueSetGuid, IPagerSettings settings);
+
+        Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(
+            Guid valueSetGuid,
+            IPagerSettings settings,
+            IEnumerable<Guid> codeSystemGuids);
+
+        Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(
+            string filterText,
+            Guid valueSetGuid,
+            IPagerSettings settings,
+            IEnumerable<Guid> codeSystemGuids);
+    }
+}

--- a/Fabric.Terminology.Domain/Services/IValueSetCodeService.cs
+++ b/Fabric.Terminology.Domain/Services/IValueSetCodeService.cs
@@ -18,10 +18,19 @@
         /// </remarks>
         IReadOnlyCollection<IValueSetCode> GetValueSetCodesByCodeGuid(Guid codeGuid);
 
+        Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(IPagerSettings settings);
+
+        Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(IPagerSettings settings, IEnumerable<Guid> codeSystemGuids);
+
         Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(Guid valueSetGuid, IPagerSettings settings);
 
         Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(
             Guid valueSetGuid,
+            IPagerSettings settings,
+            IEnumerable<Guid> codeSystemGuids);
+
+        Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(
+            string filterText,
             IPagerSettings settings,
             IEnumerable<Guid> codeSystemGuids);
 

--- a/Fabric.Terminology.IntegrationTests/Fixtures/ServiceFixture.cs
+++ b/Fabric.Terminology.IntegrationTests/Fixtures/ServiceFixture.cs
@@ -32,7 +32,8 @@
             var valueSetCodeRepository = new SqlValueSetCodeRepository(
                 this.SharedContext,
                 this.Logger,
-                cacheManagerFactory);
+                cacheManagerFactory,
+                pagingStrategyFactory);
 
             var valueSetCodeCountRepository = new SqlValueSetCodeCountRepository(
                 this.SharedContext,

--- a/Fabric.Terminology.IntegrationTests/Fixtures/SqlServiceFixture.cs
+++ b/Fabric.Terminology.IntegrationTests/Fixtures/SqlServiceFixture.cs
@@ -16,6 +16,8 @@
 
         public IValueSetService ValueSetService { get; private set; }
 
+        public IValueSetCodeService ValueSetCodeService { get; private set; }
+
         public IValueSetSummaryService ValueSetSummaryService { get; private set; }
 
         public IClientTermValueSetService ClientTermValueSetService { get; private set; }
@@ -32,7 +34,8 @@
             var valueSetCodeRepository = new SqlValueSetCodeRepository(
                 this.SharedContext,
                 this.Logger,
-                cacheManagerFactory);
+                cacheManagerFactory,
+                pagingStrategyFactory);
 
             var valueSetCodeCountRepository = new SqlValueSetCodeCountRepository(
                 this.SharedContext,
@@ -64,6 +67,8 @@
                 valueSetBackingItemRepository,
                 valueSetCodeRepository,
                 valueSetCodeCountRepository);
+
+            this.ValueSetCodeService = new SqlValueSetCodeService(valueSetCodeRepository);
 
             this.ClientTermValueSetService = new SqlClientTermValueSetService(
                 this.Logger,

--- a/Fabric.Terminology.IntegrationTests/Fixtures/ValueSetCodeRepositoryFixture.cs
+++ b/Fabric.Terminology.IntegrationTests/Fixtures/ValueSetCodeRepositoryFixture.cs
@@ -20,7 +20,8 @@
             this.ValueSetCodeRepository = new SqlValueSetCodeRepository(
                 this.SharedContext,
                 this.Logger,
-                new CachingManagerFactory(this.Cache));
+                new CachingManagerFactory(this.Cache),
+                new PagingStrategyFactory());
         }
     }
 }

--- a/Fabric.Terminology.IntegrationTests/Services/SqlValueSetCodeServiceTests.cs
+++ b/Fabric.Terminology.IntegrationTests/Services/SqlValueSetCodeServiceTests.cs
@@ -1,0 +1,80 @@
+﻿namespace Fabric.Terminology.IntegrationTests.Services
+{
+    using System;
+
+    using Fabric.Terminology.Domain.Models;
+    using Fabric.Terminology.Domain.Services;
+    using Fabric.Terminology.IntegrationTests.Fixtures;
+    using Fabric.Terminology.TestsBase;
+
+    using FluentAssertions;
+
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class SqlValueSetCodeServiceTests : OutputTestBase, IClassFixture<SqlServiceFixture>
+    {
+        private readonly IValueSetCodeService valueSetCodeService;
+
+        public SqlValueSetCodeServiceTests(SqlServiceFixture fixture, ITestOutputHelper output)
+            : base(output)
+        {
+            this.valueSetCodeService = fixture.ValueSetCodeService;
+        }
+
+        [Theory]
+        [InlineData("35F6B1A6-A72B-48F5-B319-F6CCAF15734D")]
+        [InlineData("A2216AAC-8513-43D8-85C2-00057F92394B")]
+        [InlineData("31EA98DC-D050-47A2-9435-002C19CEBF8F")]
+        public void CanGetValueSetCodesByValueSet(string valueSetReferenceId)
+        {
+            // Arrange
+            var valueSetGuid = Guid.Parse(valueSetReferenceId);
+
+            // Act
+            var codes = this.Profiler.ExecuteTimed(() => this.valueSetCodeService.GetValueSetCodes(valueSetGuid));
+
+            // Assert
+            codes.Should().NotBeEmpty();
+            this.Output.WriteLine($"Code count: {codes.Count}");
+        }
+
+        [Theory]
+        [InlineData("35F6B1A6-A72B-48F5-B319-F6CCAF15734D", 10, 6)]
+        [InlineData("A2216AAC-8513-43D8-85C2-00057F92394B", 10, 2)]
+        [InlineData("31EA98DC-D050-47A2-9435-002C19CEBF8F", 20, 2)]
+        public void CanGetValueSetCodesPageByValueSet(string valueSetReferenceId, int itemsPerPage, int pageNumber)
+        {
+            // Arrange
+            var valueSetGuid = Guid.Parse(valueSetReferenceId);
+            var pageSettings = new PagerSettings { CurrentPage = pageNumber, ItemsPerPage = itemsPerPage};
+
+            // Act
+            var page = this.Profiler.ExecuteTimed(async () => await this.valueSetCodeService.GetValueSetCodesAsync(valueSetGuid, pageSettings));
+
+            this.Output.WriteLine($"Total Values {page.TotalItems}");
+            this.Output.WriteLine($"Total Pages {page.TotalPages}");
+            this.Output.WriteLine($"Current page {page.PagerSettings.CurrentPage}");
+
+            // Assert
+            page.TotalItems.Should().BeGreaterThan(0);
+            page.TotalPages.Should().BeGreaterThan(0);
+            page.Values.Count.Should().BeLessOrEqualTo(itemsPerPage);
+        }
+
+        [Theory]
+        [InlineData("96B49FE8-7636-4741-AB2E-0C6EF5E1BC8B")]
+        public void GetValueSetCodesByCodeGuid(string codeReferenceId)
+        {
+            // Arrange
+            var codeGuid = Guid.Parse(codeReferenceId);
+
+            // Act
+            var codes = this.valueSetCodeService.GetValueSetCodesByCodeGuid(codeGuid);
+
+            // Assert
+            codes.Should().NotBeEmpty();
+            this.Output.WriteLine($"Code count: {codes.Count}");
+        }
+    }
+}

--- a/Fabric.Terminology.IntegrationTests/Services/SqlValueSetCodeServiceTests.cs
+++ b/Fabric.Terminology.IntegrationTests/Services/SqlValueSetCodeServiceTests.cs
@@ -76,5 +76,28 @@
             codes.Should().NotBeEmpty();
             this.Output.WriteLine($"Code count: {codes.Count}");
         }
+
+        [Theory]
+        [InlineData(10, 1)]
+        [InlineData(20, 2)]
+        [InlineData(20, 3)]
+        [InlineData(100, 1)]
+        [InlineData(100, 2)]
+        public void GetValueSetCodes(int itemsPerPage, int pageNumber)
+        {
+            // Arrange
+            var pagerSettings = new PagerSettings { CurrentPage = pageNumber, ItemsPerPage = itemsPerPage };
+
+            // Act
+            var page = this.Profiler.ExecuteTimed(async () => await this.valueSetCodeService.GetValueSetCodesAsync(pagerSettings));
+
+            this.Output.WriteLine($"Total Values {page.TotalItems}");
+            this.Output.WriteLine($"Total Pages {page.TotalPages}");
+
+            // Assert
+            page.TotalItems.Should().BeGreaterThan(0);
+            page.TotalPages.Should().BeGreaterThan(0);
+            page.Values.Count.Should().BeLessOrEqualTo(itemsPerPage);
+        }
     }
 }

--- a/Fabric.Terminology.SqlServer/Persistence/IValueSetCodeRepository.cs
+++ b/Fabric.Terminology.SqlServer/Persistence/IValueSetCodeRepository.cs
@@ -14,6 +14,11 @@
 
         Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(
             string filterText,
+            IPagerSettings settings,
+            IEnumerable<Guid> codeSystemGuids);
+
+        Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(
+            string filterText,
             Guid valueSetGuid,
             IPagerSettings settings,
             IEnumerable<Guid> codeSystemGuids);

--- a/Fabric.Terminology.SqlServer/Persistence/IValueSetCodeRepository.cs
+++ b/Fabric.Terminology.SqlServer/Persistence/IValueSetCodeRepository.cs
@@ -10,6 +10,14 @@
     {
         IReadOnlyCollection<IValueSetCode> GetValueSetCodes(Guid valueSetGuid);
 
+        IReadOnlyCollection<IValueSetCode> GetValueSetCodesByCodeGuid(Guid codeGuid);
+
+        Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(
+            string filterText,
+            Guid valueSetGuid,
+            IPagerSettings settings,
+            IEnumerable<Guid> codeSystemGuids);
+
         Task<Dictionary<Guid, IReadOnlyCollection<IValueSetCode>>> BuildValueSetCodesDictionary(
             IEnumerable<Guid> valueSetGuids);
     }

--- a/Fabric.Terminology.SqlServer/Persistence/SqlValueSetCodeRepository.cs
+++ b/Fabric.Terminology.SqlServer/Persistence/SqlValueSetCodeRepository.cs
@@ -5,8 +5,13 @@
     using System.Linq;
     using System.Threading.Tasks;
 
+    using CallMeMaybe;
+
+    using Fabric.Terminology.Domain;
     using Fabric.Terminology.Domain.Models;
+    using Fabric.Terminology.Domain.Persistence;
     using Fabric.Terminology.SqlServer.Caching;
+    using Fabric.Terminology.SqlServer.Models.Dto;
     using Fabric.Terminology.SqlServer.Persistence.DataContext;
     using Fabric.Terminology.SqlServer.Persistence.Factories;
 
@@ -20,15 +25,19 @@
 
         private readonly ILogger logger;
 
+        private readonly IPagingStrategyFactory pagingStrategyFactory;
+
         private readonly SharedContext sharedContext;
 
         public SqlValueSetCodeRepository(
             SharedContext sharedContext,
             ILogger logger,
-            ICachingManagerFactory cachingManagerFactory)
+            ICachingManagerFactory cachingManagerFactory,
+            IPagingStrategyFactory pagingStrategyFactory)
         {
             this.sharedContext = sharedContext;
             this.logger = logger;
+            this.pagingStrategyFactory = pagingStrategyFactory;
             this.cacheManager = cachingManagerFactory.ResolveFor<IValueSetCode>();
         }
 
@@ -37,6 +46,46 @@
             return this.cacheManager.GetMultipleOrQuery(valueSetGuid, this.QueryValueSetCodes)
                 .OrderBy(code => code.Name)
                 .ToList();
+        }
+
+        public IReadOnlyCollection<IValueSetCode> GetValueSetCodesByCodeGuid(Guid codeGuid)
+        {
+            try
+            {
+                var factory = new ValueSetCodeFactory();
+                return this.sharedContext.ValueSetCodes.Where(dto => dto.CodeGUID == codeGuid)
+                    .AsNoTracking()
+                    .ToList()
+                    .Select(factory.Build)
+                    .ToList();
+            }
+            catch (Exception ex)
+            {
+                this.logger.Error(ex, "Failed to query ValueSetCodes by CodeGuid");
+                throw;
+            }
+        }
+
+        public Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(
+            string filterText,
+            Guid valueSetGuid,
+            IPagerSettings settings,
+            IEnumerable<Guid> codeSystemGuids)
+        {
+            var dtos = this.sharedContext.ValueSetCodes.Where(dto => dto.ValueSetGUID == valueSetGuid);
+
+            if (!filterText.IsNullOrWhiteSpace())
+            {
+                dtos = dtos.Where(dto => dto.CodeDSC.Contains(filterText) || dto.CodeCD.StartsWith(filterText));
+            }
+
+            var systemCodes = codeSystemGuids as Guid[] ?? codeSystemGuids.ToArray();
+            if (systemCodes.Any())
+            {
+                dtos = dtos.Where(dto => systemCodes.Contains(dto.CodeSystemGuid));
+            }
+
+            return this.CreatePagedCollectionAsync(dtos, settings);
         }
 
         public Task<Dictionary<Guid, IReadOnlyCollection<IValueSetCode>>> BuildValueSetCodesDictionary(
@@ -77,6 +126,36 @@
                 this.logger.Error(ex, "Failed to query for ValueSetCode lookup for collection of ValueSetGUIDs");
                 throw;
             }
+        }
+
+        private async Task<PagedCollection<IValueSetCode>> CreatePagedCollectionAsync(
+            IQueryable<ValueSetCodeDto> source,
+            IPagerSettings pagerSettings)
+        {
+            var defaultItemsPerPage = this.sharedContext.Settings.DefaultItemsPerPage;
+            var pagingStrategy = this.pagingStrategyFactory.GetPagingStrategy<IValueSetCode>(defaultItemsPerPage);
+
+            pagingStrategy.EnsurePagerSettings(pagerSettings);
+
+            var count = await source.CountAsync();
+            var items = await source.OrderBy(dto => dto.CodeDSC)
+                            .Skip((pagerSettings.CurrentPage - 1) * pagerSettings.ItemsPerPage)
+                            .Take(pagerSettings.ItemsPerPage)
+                            .ToListAsync();
+
+            var factory = new ValueSetCodeFactory();
+
+            // TODO can't cache at this point since codeGuid is null in db.  Fixme
+            return pagingStrategy.CreatePagedCollection(
+                items.Select(factory.Build),
+                count,
+                pagerSettings);
+
+            //return pagingStrategy.CreatePagedCollection(
+            //    items.Select(i => this.cacheManager.GetOrSet(i.CodeGUID.GetValueOrDefault(), () => factory.Build(i))
+            //    ).Values(),
+            //    count,
+            //    pagerSettings);
         }
     }
 }

--- a/Fabric.Terminology.SqlServer/Services/SqlValueSetCodeService.cs
+++ b/Fabric.Terminology.SqlServer/Services/SqlValueSetCodeService.cs
@@ -27,9 +27,19 @@
             return this.valueSetCodeRepository.GetValueSetCodesByCodeGuid(codeGuid);
         }
 
+        public Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(IPagerSettings settings)
+        {
+            return this.GetValueSetCodesAsync(settings, new List<Guid>());
+        }
+
         public Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(
-            Guid valueSetGuid,
-            IPagerSettings settings)
+            IPagerSettings settings,
+            IEnumerable<Guid> codeSystemGuids)
+        {
+            return this.GetValueSetCodesAsync(string.Empty, settings, codeSystemGuids);
+        }
+
+        public Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(Guid valueSetGuid, IPagerSettings settings)
         {
             return this.GetValueSetCodesAsync(valueSetGuid, settings, new List<Guid>());
         }
@@ -40,6 +50,14 @@
             IEnumerable<Guid> codeSystemGuids)
         {
             return this.GetValueSetCodesAsync(string.Empty, valueSetGuid, settings, codeSystemGuids);
+        }
+
+        public Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(
+            string filterText,
+            IPagerSettings settings,
+            IEnumerable<Guid> codeSystemGuids)
+        {
+            return this.valueSetCodeRepository.GetValueSetCodesAsync(filterText, settings, codeSystemGuids);
         }
 
         public Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(

--- a/Fabric.Terminology.SqlServer/Services/SqlValueSetCodeService.cs
+++ b/Fabric.Terminology.SqlServer/Services/SqlValueSetCodeService.cs
@@ -1,0 +1,57 @@
+﻿namespace Fabric.Terminology.SqlServer.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    using Fabric.Terminology.Domain.Models;
+    using Fabric.Terminology.Domain.Services;
+    using Fabric.Terminology.SqlServer.Persistence;
+
+    using Serilog;
+
+    internal class SqlValueSetCodeService : IValueSetCodeService
+    {
+        private readonly ILogger logger;
+
+        private readonly IValueSetCodeRepository valueSetCodeRepository;
+
+        public SqlValueSetCodeService(ILogger logger, IValueSetCodeRepository valueSetCodeRepository)
+        {
+            this.logger = logger;
+            this.valueSetCodeRepository = valueSetCodeRepository;
+        }
+
+        public IReadOnlyCollection<IValueSetCode> GetValueSetCodes(Guid valueSetGuid)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IReadOnlyCollection<IValueSetCode> GetValueSetCodesByCodeGuid(Guid codeGuid)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(Guid valueSetGuid, IPagerSettings settings)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(
+            Guid valueSetGuid,
+            IPagerSettings settings,
+            IEnumerable<Guid> codeSystemGuids)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(
+            string filterText,
+            Guid valueSetGuid,
+            IPagerSettings settings,
+            IEnumerable<Guid> codeSystemGuids)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Fabric.Terminology.SqlServer/Services/SqlValueSetCodeService.cs
+++ b/Fabric.Terminology.SqlServer/Services/SqlValueSetCodeService.cs
@@ -8,33 +8,30 @@
     using Fabric.Terminology.Domain.Services;
     using Fabric.Terminology.SqlServer.Persistence;
 
-    using Serilog;
-
     internal class SqlValueSetCodeService : IValueSetCodeService
     {
-        private readonly ILogger logger;
-
         private readonly IValueSetCodeRepository valueSetCodeRepository;
 
-        public SqlValueSetCodeService(ILogger logger, IValueSetCodeRepository valueSetCodeRepository)
+        public SqlValueSetCodeService(IValueSetCodeRepository valueSetCodeRepository)
         {
-            this.logger = logger;
             this.valueSetCodeRepository = valueSetCodeRepository;
         }
 
         public IReadOnlyCollection<IValueSetCode> GetValueSetCodes(Guid valueSetGuid)
         {
-            throw new NotImplementedException();
+            return this.valueSetCodeRepository.GetValueSetCodes(valueSetGuid);
         }
 
         public IReadOnlyCollection<IValueSetCode> GetValueSetCodesByCodeGuid(Guid codeGuid)
         {
-            throw new NotImplementedException();
+            return this.valueSetCodeRepository.GetValueSetCodesByCodeGuid(codeGuid);
         }
 
-        public Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(Guid valueSetGuid, IPagerSettings settings)
+        public Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(
+            Guid valueSetGuid,
+            IPagerSettings settings)
         {
-            throw new NotImplementedException();
+            return this.GetValueSetCodesAsync(valueSetGuid, settings, new List<Guid>());
         }
 
         public Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(
@@ -42,7 +39,7 @@
             IPagerSettings settings,
             IEnumerable<Guid> codeSystemGuids)
         {
-            throw new NotImplementedException();
+            return this.GetValueSetCodesAsync(string.Empty, valueSetGuid, settings, codeSystemGuids);
         }
 
         public Task<PagedCollection<IValueSetCode>> GetValueSetCodesAsync(
@@ -51,7 +48,11 @@
             IPagerSettings settings,
             IEnumerable<Guid> codeSystemGuids)
         {
-            throw new NotImplementedException();
+            return this.valueSetCodeRepository.GetValueSetCodesAsync(
+                filterText,
+                valueSetGuid,
+                settings,
+                codeSystemGuids);
         }
     }
 }


### PR DESCRIPTION
Relates to issue discussion #71 

Adds /valuesetcodes endpoint which allows for querying value set codes.
Implements 3 methods:

1. /valuesetcodes/  - Paged list of all value set codes (unconstrained)
2. /valuesetcodes/codeGuid - List of value set codes by a specific code Guid.  Intended to be used to discover which value sets a certain code is associated.
3. /valuesetcodes/valueset/valueSetGuid - Paged collection of value set codes associated with a specific value set.