### PR TITLE
Fixes #89 - Renames legacy AuthoringSourceDescription property AuthorityDescription.

### DIFF
--- a/Fabric.Terminology.API/Models/ValueSetMetaApiModel.cs
+++ b/Fabric.Terminology.API/Models/ValueSetMetaApiModel.cs
@@ -12,7 +12,7 @@
 
         public string DefinitionDescription { get; set; }
 
-        public string AuthoringSourceDescription { get; set; }
+        public string AuthorityDescription { get; set; }
 
         public string SourceDescription { get; set; }
     }

--- a/Fabric.Terminology.Domain/Models/IValueSetMeta.cs
+++ b/Fabric.Terminology.Domain/Models/IValueSetMeta.cs
@@ -10,7 +10,7 @@
 
         string DefinitionDescription { get; }
 
-        string AuthoringSourceDescription { get; }
+        string AuthorityDescription { get; }
 
         string SourceDescription { get; }
     }

--- a/Fabric.Terminology.Domain/Models/ValueSet.cs
+++ b/Fabric.Terminology.Domain/Models/ValueSet.cs
@@ -23,7 +23,7 @@
             this.VersionDate = meta.VersionDate;
             this.ClientCode = meta.ClientCode;
             this.DefinitionDescription = meta.DefinitionDescription;
-            this.AuthoringSourceDescription = meta.AuthoringSourceDescription;
+            this.AuthorityDescription = meta.AuthorityDescription;
             this.SourceDescription = meta.SourceDescription;
             var codes = codeSetCodes.Select(c => new ValueSetCode(c)).ToList();
             this.ValueSetCodes = codes;

--- a/Fabric.Terminology.Domain/Models/ValueSetBackingItem.cs
+++ b/Fabric.Terminology.Domain/Models/ValueSetBackingItem.cs
@@ -12,7 +12,7 @@
 
         public string DefinitionDescription { get; internal set; }
 
-        public string AuthoringSourceDescription { get; internal set; }
+        public string AuthorityDescription { get; internal set; }
 
         public string SourceDescription { get; internal set; }
 

--- a/Fabric.Terminology.Domain/Models/ValueSetBase.cs
+++ b/Fabric.Terminology.Domain/Models/ValueSetBase.cs
@@ -13,7 +13,7 @@ namespace Fabric.Terminology.Domain.Models
             this.ValueSetGuid = backingItem.ValueSetGuid;
             this.Name = backingItem.Name;
             this.VersionDate = backingItem.VersionDate;
-            this.AuthoringSourceDescription = backingItem.AuthoringSourceDescription;
+            this.AuthorityDescription = backingItem.AuthorityDescription;
             this.DefinitionDescription = backingItem.DefinitionDescription;
             this.SourceDescription = backingItem.SourceDescription;
             this.ValueSetReferenceId = backingItem.ValueSetReferenceId;
@@ -28,7 +28,7 @@ namespace Fabric.Terminology.Domain.Models
 
         public string DefinitionDescription { get; internal set; }
 
-        public string AuthoringSourceDescription { get; internal set; }
+        public string AuthorityDescription { get; internal set; }
 
         public string SourceDescription { get; internal set; }
 

--- a/Fabric.Terminology.SqlServer/Models/Dto/ValueSetDescriptionBASEDto.cs
+++ b/Fabric.Terminology.SqlServer/Models/Dto/ValueSetDescriptionBASEDto.cs
@@ -21,6 +21,7 @@ namespace Fabric.Terminology.SqlServer.Models.Dto
             this.ValueSetNM = valueSet.Name;
             this.VersionDTS = valueSet.VersionDate;
             this.DefinitionDSC = valueSet.DefinitionDescription;
+            this.AuthorityDSC = valueSet.AuthorityDescription;
             this.SourceDSC = valueSet.SourceDescription;
             this.StatusCD = valueSet.StatusCode.ToString();
             this.OriginGUID = valueSet.OriginGuid;

--- a/Fabric.Terminology.SqlServer/Persistence/Factories/ValueSetBackingItemFactory.cs
+++ b/Fabric.Terminology.SqlServer/Persistence/Factories/ValueSetBackingItemFactory.cs
@@ -23,7 +23,7 @@
 
             return new ValueSetBackingItem
             {
-                AuthoringSourceDescription = dto.AuthorityDSC,
+                AuthorityDescription = dto.AuthorityDSC,
                 ClientCode = dto.ClientCD,
                 DefinitionDescription = dto.DefinitionDSC,
                 IsLatestVersion = dto.LatestVersionFLG == "Y",

--- a/Fabric.Terminology.SqlServer/Persistence/SqlClientTermValueSetRepository.cs
+++ b/Fabric.Terminology.SqlServer/Persistence/SqlClientTermValueSetRepository.cs
@@ -105,7 +105,7 @@ namespace Fabric.Terminology.SqlServer.Persistence
 
                 vsd.SourceDSC = parameters.ValueSetMeta.SourceDescription;
                 vsd.ValueSetNM = parameters.Name;
-                vsd.AuthorityDSC = parameters.ValueSetMeta.AuthoringSourceDescription;
+                vsd.AuthorityDSC = parameters.ValueSetMeta.AuthorityDescription;
                 vsd.ClientCD = parameters.ValueSetMeta.ClientCode;
                 vsd.DefinitionDSC = parameters.ValueSetMeta.DefinitionDescription;
 

--- a/Fabric.Terminology.SqlServer/Services/SqlClientTermValueSetService.cs
+++ b/Fabric.Terminology.SqlServer/Services/SqlClientTermValueSetService.cs
@@ -93,7 +93,7 @@
                             return this.clientTermValueSetRepository.Patch(parameters);
                         })
                 .Else(Attempt<IValueSet>
-                        .Failed(new InvalidOperationException(FormattableString.Invariant($"ValueSet with with ValueSetGUID {parameters.ValueSetGuid} was not found."))));
+                        .Failed(new InvalidOperationException(FormattableString.Invariant($"ValueSet with ValueSetGUID {parameters.ValueSetGuid} was not found."))));
         }
 
         public void SaveAsNew(IValueSet valueSet)
@@ -189,7 +189,7 @@
             var errors = new List<string>
             {
                 ValidateProperty(nameof(meta.ClientCode), meta.ClientCode),
-                ValidateProperty(nameof(meta.AuthoringSourceDescription), meta.AuthoringSourceDescription),
+                ValidateProperty(nameof(meta.AuthorityDescription), meta.AuthorityDescription),
                 ValidateProperty(nameof(meta.DefinitionDescription), meta.DefinitionDescription),
                 ValidateProperty(nameof(meta.SourceDescription), meta.SourceDescription)
             };

--- a/Fabric.Terminology.TestsBase/DataHelper.cs
+++ b/Fabric.Terminology.TestsBase/DataHelper.cs
@@ -36,7 +36,7 @@
             return new ValueSet
             {
                 ValueSetGuid = valueSetGuid,
-                AuthoringSourceDescription = "author",
+                AuthorityDescription = "author",
                 IsCustom = true,
                 Name = $"test{settings.IdSuffix}",
                 DefinitionDescription = "purpose",

--- a/Fabric.Terminology.TestsBase/Mocks/MockApiModelBuilder.cs
+++ b/Fabric.Terminology.TestsBase/Mocks/MockApiModelBuilder.cs
@@ -28,7 +28,7 @@
             return new ClientTermValueSetApiModel
             {
                 Name = name,
-                AuthoringSourceDescription = "Test Authoring Source Description",
+                AuthorityDescription = "Test Authoring Source Description",
                 DefinitionDescription = "Test Purpose Description",
                 SourceDescription = "Test Source Description",
                 CodeOperations = instructions,


### PR DESCRIPTION
**Breaking UI Model Change**:  valueSet and valueSetSummary models - authoringSourceDescription property has been renamed - authorityDescription.