### PR TITLE
Refactors value set queries to all for multiple status filters.

### DIFF
--- a/Fabric.Terminology.API/MetaData/ParameterFactory.cs
+++ b/Fabric.Terminology.API/MetaData/ParameterFactory.cs
@@ -86,8 +86,8 @@
                 Description = "The ValueSet status code.  Valid values are 'Active', 'Draft', 'Archived'",
                 Required = false,
                 In = ParameterIn.Query,
-                Type = "string",
-                Enum = new[] { "Active", "Draft", "Archived" }
+                CollectionFormat = CollectionFormats.Csv,
+                Type = "string"
             };
         }
 

--- a/Fabric.Terminology.API/Models/ValueSetFindByTermQuery.cs
+++ b/Fabric.Terminology.API/Models/ValueSetFindByTermQuery.cs
@@ -1,5 +1,7 @@
 ﻿namespace Fabric.Terminology.API.Models
 {
+    using System.Collections.Generic;
+
     using Fabric.Terminology.Domain;
 
     using Newtonsoft.Json;
@@ -9,7 +11,7 @@
         [JsonProperty("summary")]
         public bool Summary { get; set; } = true;
 
-        [JsonProperty("statusCode")]
-        public ValueSetStatus StatusCode { get; set; } = ValueSetStatus.Active;
+        [JsonProperty("statusCodes")]
+        public IEnumerable<ValueSetStatus> StatusCodes { get; set; } = new List<ValueSetStatus> { ValueSetStatus.Active };
     }
 }

--- a/Fabric.Terminology.API/Modules/TerminologyModule.cs
+++ b/Fabric.Terminology.API/Modules/TerminologyModule.cs
@@ -109,7 +109,7 @@
             }
         }
 
-        private string[] CreateParameterArray(string value, char splitChar = ',')
+        protected string[] CreateParameterArray(string value, char splitChar = ',')
         {
             if (value.IsNullOrWhiteSpace())
             {

--- a/Fabric.Terminology.API/Modules/ValueSetModule.cs
+++ b/Fabric.Terminology.API/Modules/ValueSetModule.cs
@@ -255,14 +255,14 @@
                                   model.Term,
                                   model.PagerSettings,
                                   codeSystemGuids,
-                                  model.StatusCode))
+                                  model.StatusCodes))
                             .ToValueSetApiModelPage(codeSystemGuids, MapToValueSetItemApiModel)
 
                            : (await this.valueSetService.GetValueSetsAsync(
                                   model.Term,
                                   model.PagerSettings,
                                   codeSystemGuids,
-                                  model.StatusCode))
+                                  model.StatusCodes))
                             .ToValueSetApiModelPage(codeSystemGuids, MapToValueSetApiModel);
             }
             catch (Exception ex)
@@ -469,14 +469,18 @@
             return val.IsNullOrWhiteSpace() || ret;
         }
 
-        private ValueSetStatus GetValueSetStatusCode()
+        private IEnumerable<ValueSetStatus> GetValueSetStatusCode()
         {
-            if (!Enum.TryParse((string)this.Request.Query["$status"], true, out ValueSetStatus statusCode))
+            var statuses = this.CreateParameterArray((string)this.Request.Query["$status"]);
+            foreach (var status in statuses)
             {
-                statusCode = ValueSetStatus.Active;
-            }
+                if (!Enum.TryParse(status, true, out ValueSetStatus statusCode))
+                {
+                    statusCode = ValueSetStatus.Active;
+                }
 
-            return statusCode;
+                yield return statusCode;
+            }
         }
 
         private ValueSetFindByTermQuery EnsureQueryModel(ValueSetFindByTermQuery model)

--- a/Fabric.Terminology.Domain/Services/IValueSetService.cs
+++ b/Fabric.Terminology.Domain/Services/IValueSetService.cs
@@ -27,26 +27,26 @@
 
         Task<PagedCollection<IValueSet>> GetValueSetsAsync(
             IPagerSettings settings,
-            ValueSetStatus statusCode = ValueSetStatus.Active,
+            IEnumerable<ValueSetStatus> statusCodes,
             bool latestVersionsOnly = true);
 
         Task<PagedCollection<IValueSet>> GetValueSetsAsync(
             IPagerSettings settings,
             IEnumerable<Guid> codeSystemGuids,
-            ValueSetStatus statusCode = ValueSetStatus.Active,
+            IEnumerable<ValueSetStatus> statusCodes,
             bool latestVersionsOnly = true);
 
         Task<PagedCollection<IValueSet>> GetValueSetsAsync(
             string filterText,
             IPagerSettings pagerSettings,
-            ValueSetStatus statusCode = ValueSetStatus.Active,
+            IEnumerable<ValueSetStatus> statusCodes,
             bool latestVersionsOnly = true);
 
         Task<PagedCollection<IValueSet>> GetValueSetsAsync(
             string filterText,
             IPagerSettings pagerSettings,
             IEnumerable<Guid> codeSystemGuids,
-            ValueSetStatus statusCode = ValueSetStatus.Active,
+            IEnumerable<ValueSetStatus> statusCodes,
             bool latestVersionsOnly = true);
     }
 }

--- a/Fabric.Terminology.Domain/Services/IValueSetService.cs
+++ b/Fabric.Terminology.Domain/Services/IValueSetService.cs
@@ -27,6 +27,10 @@
 
         Task<PagedCollection<IValueSet>> GetValueSetsAsync(
             IPagerSettings settings,
+            bool latestVersionsOnly = true);
+
+        Task<PagedCollection<IValueSet>> GetValueSetsAsync(
+            IPagerSettings settings,
             IEnumerable<ValueSetStatus> statusCodes,
             bool latestVersionsOnly = true);
 

--- a/Fabric.Terminology.Domain/Services/IValueSetSummaryService.cs
+++ b/Fabric.Terminology.Domain/Services/IValueSetSummaryService.cs
@@ -24,6 +24,10 @@
 
         Task<PagedCollection<IValueSetSummary>> GetValueSetSummariesAsync(
             IPagerSettings settings,
+            bool latestVersionsOnly = true);
+
+        Task<PagedCollection<IValueSetSummary>> GetValueSetSummariesAsync(
+            IPagerSettings settings,
             IEnumerable<ValueSetStatus> statusCodes,
             bool latestVersionsOnly = true);
 

--- a/Fabric.Terminology.Domain/Services/IValueSetSummaryService.cs
+++ b/Fabric.Terminology.Domain/Services/IValueSetSummaryService.cs
@@ -24,26 +24,26 @@
 
         Task<PagedCollection<IValueSetSummary>> GetValueSetSummariesAsync(
             IPagerSettings settings,
-            ValueSetStatus statusCode = ValueSetStatus.Active,
+            IEnumerable<ValueSetStatus> statusCodes,
             bool latestVersionsOnly = true);
 
         Task<PagedCollection<IValueSetSummary>> GetValueSetSummariesAsync(
             IPagerSettings settings,
             IEnumerable<Guid> codeSystemGuids,
-            ValueSetStatus statusCode = ValueSetStatus.Active,
+            IEnumerable<ValueSetStatus> statusCodes,
             bool latestVersionsOnly = true);
 
         Task<PagedCollection<IValueSetSummary>> GetValueSetSummariesAsync(
             string nameFilterText,
             IPagerSettings pagerSettings,
-            ValueSetStatus statusCode = ValueSetStatus.Active,
+            IEnumerable<ValueSetStatus> statusCodes,
             bool latestVersionsOnly = true);
 
         Task<PagedCollection<IValueSetSummary>> GetValueSetSummariesAsync(
             string nameFilterText,
             IPagerSettings pagerSettings,
             IEnumerable<Guid> codeSystemGuids,
-            ValueSetStatus statusCode = ValueSetStatus.Active,
+            IEnumerable<ValueSetStatus> statusCodes,
             bool latestVersionsOnly = true);
     }
 }

--- a/Fabric.Terminology.IntegrationTests/Repositories/SqlValueSetBackingItemRepositoryTests.cs
+++ b/Fabric.Terminology.IntegrationTests/Repositories/SqlValueSetBackingItemRepositoryTests.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
 
+    using Fabric.Terminology.Domain;
     using Fabric.Terminology.Domain.Models;
     using Fabric.Terminology.IntegrationTests.Fixtures;
     using Fabric.Terminology.SqlServer.Persistence;
@@ -49,7 +50,7 @@
             var pagerSettings = new PagerSettings { CurrentPage = pageNumber, ItemsPerPage = itemsPerPage };
 
             // Act
-            var page = this.Profiler.ExecuteTimed(async () => await this.repository.GetValueSetBackingItemsAsync(pagerSettings, new List<Guid>()));
+            var page = this.Profiler.ExecuteTimed(async () => await this.repository.GetValueSetBackingItemsAsync(pagerSettings, new List<Guid>(), new List<ValueSetStatus> { ValueSetStatus.Active }));
             this.Output.WriteLine($"Total Values {page.TotalItems}");
             this.Output.WriteLine($"Total Pages {page.TotalPages}");
 

--- a/Fabric.Terminology.SqlServer/Persistence/IValueSetBackingItemRepository.cs
+++ b/Fabric.Terminology.SqlServer/Persistence/IValueSetBackingItemRepository.cs
@@ -28,14 +28,14 @@
         Task<PagedCollection<IValueSetBackingItem>> GetValueSetBackingItemsAsync(
             IPagerSettings pagerSettings,
             IEnumerable<Guid> codeSystemGuids,
-            ValueSetStatus statusCode = ValueSetStatus.Active,
+            IEnumerable<ValueSetStatus> statusCodes,
             bool latestVersionsOnly = true);
 
         Task<PagedCollection<IValueSetBackingItem>> GetValueSetBackingItemsAsync(
             string filterText,
             IPagerSettings pagerSettings,
             IEnumerable<Guid> codeSystemGuids,
-            ValueSetStatus statusCode = ValueSetStatus.Active,
+            IEnumerable<ValueSetStatus> statusCodes,
             bool latestVersionsOnly = true);
 
         bool ValueSetGuidExists(Guid valueSetGuid);

--- a/Fabric.Terminology.SqlServer/Services/SqlValueSetService.cs
+++ b/Fabric.Terminology.SqlServer/Services/SqlValueSetService.cs
@@ -93,42 +93,42 @@ namespace Fabric.Terminology.SqlServer.Services
 
         public Task<PagedCollection<IValueSet>> GetValueSetsAsync(
             IPagerSettings settings,
-            ValueSetStatus statusCode = ValueSetStatus.Active,
+            IEnumerable<ValueSetStatus> statusCodes,
             bool latestVersionsOnly = true)
         {
-            return this.GetValueSetsAsync(settings, new List<Guid>(), statusCode, latestVersionsOnly);
+            return this.GetValueSetsAsync(settings, new List<Guid>(), statusCodes, latestVersionsOnly);
         }
 
         public Task<PagedCollection<IValueSet>> GetValueSetsAsync(
             IPagerSettings settings,
             IEnumerable<Guid> codeSystemGuids,
-            ValueSetStatus statusCode = ValueSetStatus.Active,
+            IEnumerable<ValueSetStatus> statusCodes,
             bool latestVersionsOnly = true)
         {
-            return this.GetValueSetsAsync(string.Empty, settings, codeSystemGuids, statusCode, latestVersionsOnly);
+            return this.GetValueSetsAsync(string.Empty, settings, codeSystemGuids, statusCodes, latestVersionsOnly);
         }
 
         public Task<PagedCollection<IValueSet>> GetValueSetsAsync(
             string filterText,
             IPagerSettings pagerSettings,
-            ValueSetStatus statusCode = ValueSetStatus.Active,
+            IEnumerable<ValueSetStatus> statusCodes,
             bool latestVersionsOnly = true)
         {
-            return this.GetValueSetsAsync(filterText, pagerSettings, new List<Guid>(), statusCode, latestVersionsOnly);
+            return this.GetValueSetsAsync(filterText, pagerSettings, new List<Guid>(), statusCodes, latestVersionsOnly);
         }
 
         public async Task<PagedCollection<IValueSet>> GetValueSetsAsync(
             string filterText,
             IPagerSettings pagerSettings,
             IEnumerable<Guid> codeSystemGuids,
-            ValueSetStatus statusCode = ValueSetStatus.Active,
+            IEnumerable<ValueSetStatus> statusCodes,
             bool latestVersionsOnly = true)
         {
             var backingItemPage = await this.valueSetBackingItemRepository.GetValueSetBackingItemsAsync(
                                       filterText,
                                       pagerSettings,
                                       codeSystemGuids,
-                                      statusCode,
+                                      statusCodes,
                                       latestVersionsOnly);
 
             var valueSetGuids = backingItemPage.Values.Select(bi => bi.ValueSetGuid).ToList();

--- a/Fabric.Terminology.SqlServer/Services/SqlValueSetService.cs
+++ b/Fabric.Terminology.SqlServer/Services/SqlValueSetService.cs
@@ -91,6 +91,15 @@ namespace Fabric.Terminology.SqlServer.Services
             return this.BuildValueSets(backingItems, codes, counts);
         }
 
+        public Task<PagedCollection<IValueSet>> GetValueSetsAsync(IPagerSettings settings, bool latestVersionsOnly = true)
+        {
+            return this.GetValueSetsAsync(
+                settings,
+                new List<Guid>(),
+                new List<ValueSetStatus> { ValueSetStatus.Active },
+                latestVersionsOnly);
+        }
+
         public Task<PagedCollection<IValueSet>> GetValueSetsAsync(
             IPagerSettings settings,
             IEnumerable<ValueSetStatus> statusCodes,

--- a/Fabric.Terminology.SqlServer/Services/SqlValueSetSummaryService.cs
+++ b/Fabric.Terminology.SqlServer/Services/SqlValueSetSummaryService.cs
@@ -84,47 +84,47 @@
 
         public Task<PagedCollection<IValueSetSummary>> GetValueSetSummariesAsync(
             IPagerSettings settings,
-            ValueSetStatus statusCode = ValueSetStatus.Active,
+            IEnumerable<ValueSetStatus> statusCodes,
             bool latestVersionsOnly = true)
         {
-            return this.GetValueSetSummariesAsync(settings, new List<Guid>(), statusCode, latestVersionsOnly);
+            return this.GetValueSetSummariesAsync(settings, new List<Guid>(), statusCodes, latestVersionsOnly);
         }
 
         public Task<PagedCollection<IValueSetSummary>> GetValueSetSummariesAsync(
             IPagerSettings settings,
             IEnumerable<Guid> codeSystemGuids,
-            ValueSetStatus statusCode = ValueSetStatus.Active,
+            IEnumerable<ValueSetStatus> statusCodes,
             bool latestVersionsOnly = true)
         {
             return this.GetValueSetSummariesAsync(
                 string.Empty,
                 settings,
                 codeSystemGuids,
-                statusCode,
+                statusCodes,
                 latestVersionsOnly);
         }
 
         public Task<PagedCollection<IValueSetSummary>> GetValueSetSummariesAsync(
             string nameFilterText,
             IPagerSettings pagerSettings,
-            ValueSetStatus statusCode = ValueSetStatus.Active,
+            IEnumerable<ValueSetStatus> statusCodes,
             bool latestVersionsOnly = true)
         {
-            return this.GetValueSetSummariesAsync(nameFilterText, pagerSettings, new List<Guid>(), statusCode, latestVersionsOnly);
+            return this.GetValueSetSummariesAsync(nameFilterText, pagerSettings, new List<Guid>(), statusCodes, latestVersionsOnly);
         }
 
         public async Task<PagedCollection<IValueSetSummary>> GetValueSetSummariesAsync(
             string nameFilterText,
             IPagerSettings pagerSettings,
             IEnumerable<Guid> codeSystemGuids,
-            ValueSetStatus statusCode = ValueSetStatus.Active,
+            IEnumerable<ValueSetStatus> statusCodes,
             bool latestVersionsOnly = true)
         {
             var backingItemPage = await this.valueSetBackingItemRepository.GetValueSetBackingItemsAsync(
                                       nameFilterText,
                                       pagerSettings,
                                       codeSystemGuids,
-                                      statusCode,
+                                      statusCodes,
                                       latestVersionsOnly);
 
             var countsDictionary =

--- a/Fabric.Terminology.SqlServer/Services/SqlValueSetSummaryService.cs
+++ b/Fabric.Terminology.SqlServer/Services/SqlValueSetSummaryService.cs
@@ -82,6 +82,11 @@
             return this.BuildValueSetSummaries(backingItems, counts);
         }
 
+        public Task<PagedCollection<IValueSetSummary>> GetValueSetSummariesAsync(IPagerSettings settings, bool latestVersionsOnly = true)
+        {
+            return this.GetValueSetSummariesAsync(settings, new List<Guid>(), new List<ValueSetStatus> { ValueSetStatus.Active }, latestVersionsOnly);
+        }
+
         public Task<PagedCollection<IValueSetSummary>> GetValueSetSummariesAsync(
             IPagerSettings settings,
             IEnumerable<ValueSetStatus> statusCodes,


### PR DESCRIPTION
@corytak Note there is a breaking change in the API search model.

e.g.  **statusCode** property has been renamed **statusCodes**
