### PR TITLE
Tweak install.config - add appEndpoint, move appPool

### DIFF
--- a/Fabric.Terminology.API/Scripts/Install.config
+++ b/Fabric.Terminology.API/Scripts/Install.config
@@ -6,6 +6,9 @@
       <variable name="sqlServerAddress" value="" />
       <!-- The name of the app and app pool that will be created in IIS -->
       <variable name="appName" value="TerminologyService" />
+      <variable name="appPool" value="Terminology" />
+      <!-- The URI for the Terminology Service -->
+      <variable name="appEndpoint" value="" />
       <!-- The name of the IIS website to install the application under -->
       <variable name="siteName" value="Default Web Site" />
       <!-- The name of the Shared database on the sql server instance -->
@@ -13,7 +16,6 @@
       <!-- The user account for the app to run under in IIS -->
       <variable name="iisUser" value="" />
       <variable name="iisUserPwd" value="" />
-      <variable name="appPool" value="Terminology" />
       <!-- The Sql Server role that the app pool user will be added to -->
       <variable name="databaseRole" value="TerminologyServiceRole" />
       <variable name="discoveryServiceUrl" value="" />


### PR DESCRIPTION
Adding appEndpoint parameter to install.config.  No default parameter but now the user installing Terminology can specify that before running the installer.  Also moved appPool parameter up under appName as the two are pointed out together in the comments.