### PR TITLE
User/bena/install script tweaks

### DIFF
--- a/Fabric.Terminology.API/Scripts/Install-Terminology.ps1
+++ b/Fabric.Terminology.API/Scripts/Install-Terminology.ps1
@@ -34,7 +34,7 @@
     [switch] $Quiet
 )
 
-[string[]] $requiredFiles = @($InstallFile, $Dacpac, $PublishProfile, "$PSScriptRoot\Install.config", "$PSScriptRoot\Register.ps1", "$PSScriptRoot\Terminology-Install-Utilities.psm1", "$PSScriptRoot\registration.config")
+[string[]] $requiredFiles = @($InstallFile, $Dacpac, $PublishProfile, "$PSScriptRoot\Install.config", "$PSScriptRoot\Terminology-Install-Utilities.psm1", "$PSScriptRoot\registration.config")
 For ($i = 0; $i -lt $requiredFiles.Length; $i++) {
     if (!(Test-Path -Path $requiredFiles[$i])) {
         Throw "$($requiredFiles[$i]) does not exist and is required for install."
@@ -42,16 +42,11 @@ For ($i = 0; $i -lt $requiredFiles.Length; $i++) {
 }
 
 # Import Dos Install Utilities
-$dosInstallUtilities = Get-Childitem -Path ./**/DosInstallUtilities.psm1 -Recurse
-if ($dosInstallUtilities.length -eq 0) {
-    Install-Module DosInstallUtilities -Scope CurrentUser
-    Import-Module DosInstallUtilities -Force
-    Write-DosMessage -Level "Warning" -Message "Could not find DosInstallUtilities. Manually installing..."
-}
-else {
-    Import-Module -Name $dosInstallUtilities.FullName
-    Write-DosMessage -Level "Verbose" -Message "Installing DosInstallUtilities at $($dosInstallUtilities.FullName)"
-}
+$MinimumVersion = [Version]::new(1, 0, 163)
+Import-Module -Name DosInstallUtilities -MinimumVersion $MinimumVersion -ErrorAction Stop
+
+# DBA tools
+Import-Module -Name dbatools -ErrorAction Stop
  
 # Import Fabric Install Utilities
 $fabricInstallUtilities = ".\Fabric-Install-Utilities.psm1"
@@ -59,14 +54,16 @@ if (!(Test-Path $fabricInstallUtilities -PathType Leaf)) {
     Write-DosMessage -Level "Warning" -Message "Could not find FabricInstallUtilities. Manually downloading and installing..."
     Invoke-WebRequest -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -Headers @{"Cache-Control" = "no-cache"} -OutFile $fabricInstallUtilities
 }
-
-# DBA tools
-Install-Module dbatools
+Import-Module -Name $fabricInstallUtilities -Force
 
 # IIS web administration
-Import-Module WebAdministration
-
-Import-Module -Name $fabricInstallUtilities -Force
+try {
+    Import-Module WebAdministration
+}
+catch {
+    Write-Error -Message "Error importing module WebAdministration. Please verify IIS installed and you are running Windows Server 2012 or above"
+    throw $_.Exception
+}
 
 # Download Registration Script
 $fabricRegistration = ".\Register.ps1"

--- a/Fabric.Terminology.API/Scripts/Install-Terminology.ps1
+++ b/Fabric.Terminology.API/Scripts/Install-Terminology.ps1
@@ -34,6 +34,9 @@
     [switch] $Quiet
 )
 
+# Fail installation on first error
+$ErrorActionPreference = "Stop"
+
 [string[]] $requiredFiles = @($InstallFile, $Dacpac, $PublishProfile, "$PSScriptRoot\Install.config", "$PSScriptRoot\Terminology-Install-Utilities.psm1", "$PSScriptRoot\registration.config")
 For ($i = 0; $i -lt $requiredFiles.Length; $i++) {
     if (!(Test-Path -Path $requiredFiles[$i])) {

--- a/Fabric.Terminology.API/Scripts/Install.config
+++ b/Fabric.Terminology.API/Scripts/Install.config
@@ -18,13 +18,13 @@
       <variable name="iisUserPwd" value="" />
       <!-- The Sql Server role that the app pool user will be added to -->
       <variable name="databaseRole" value="TerminologyServiceRole" />
-      <variable name="discoveryServiceUrl" value="" />
       <variable name="appInsightsInstrumentationKey" value="" />
     </scope>
     <scope name="common">
       <variable name="metadataDbName" value="EDWAdmin" />
       <variable name="sqlDataDirectory" value="" />
       <variable name="sqlLogDirectory" value="" />
+      <variable name="discoveryService" value="" />
     </scope>
   </settings>
 </installation>

--- a/Fabric.Terminology.API/Scripts/Terminology-Install-Utilities.psm1
+++ b/Fabric.Terminology.API/Scripts/Terminology-Install-Utilities.psm1
@@ -203,7 +203,7 @@ function Get-TerminologyConfig {
     $installSettings = Get-InstallationSettings "terminology"
 
     # Discovery Service Url
-    $discoveryServiceUrlConfig = Get-ConfigValue -Prompt "Discovery Service URI" -AdditionalPromptInfo "(eg. https://SERVER/DiscoveryService/v1)" -DefaultFromParam $DiscoveryServiceUrl -DefaultFromInstallConfig $installSettings.discoveryServiceUrl -Quiet:$Quiet
+    $discoveryServiceUrlConfig = Get-ConfigValue -Prompt "Discovery Service URI" -AdditionalPromptInfo "(eg. https://SERVER/DiscoveryService/v1)" -DefaultFromParam $DiscoveryServiceUrl -DefaultFromInstallConfig $installSettings.discoveryService -Quiet:$Quiet
 
     # Validate Service Dependencies
     $services = @{ServiceName = "MetadataService"; Version = 2}, @{ServiceName = "DataProcessingService"; Version = 1}, @{ServiceName = "IdentityService"; Version = 1}, @{ServiceName = "AuthorizationService"; Version = 1}
@@ -304,9 +304,9 @@ function Get-TerminologyConfig {
 
     Add-InstallationSetting "terminology" "appName" "$appNameConfig" | Out-Null
     Add-InstallationSetting "terminology" "appEndpoint" "$terminologyEndpointConfig" | Out-Null
-    Add-InstallationSetting "terminology" "discoveryServiceUrl" "$discoveryServiceUrlConfig" | Out-Null
-    Add-InstallationSetting "terminology" "sqlServerAddress" "$sqlAddressConfig" | Out-Null
     Add-InstallationSetting "terminology" "appInsightsInstrumentationKey" "$appInsightsKeyConfig" | Out-Null
+    Add-InstallationSetting "common" "discoveryService" "$discoveryServiceUrlConfig" | Out-Null
+    Add-InstallationSetting "common" "sqlServerAddress" "$sqlAddressConfig" | Out-Null
     Add-InstallationSetting "common" "metadataDbName" "$metadataDbNameConfig" | Out-Null
     Add-InstallationSetting "common" "sqlDataDirectory" "$sqlDataDirectoryConfig" | Out-Null
     Add-InstallationSetting "common" "sqlLogDirectory" "$sqlLogDirectoryConfig" | Out-Null

--- a/Fabric.Terminology.API/Scripts/Terminology-Install-Utilities.psm1
+++ b/Fabric.Terminology.API/Scripts/Terminology-Install-Utilities.psm1
@@ -421,7 +421,7 @@ function Publish-TerminologyDacpac() {
     $log.InnerText = $Config.sqlDataDirectory
     $publishProfileXml.Save($PublishProfile);
     
-    Write-DosMessage -Level "Information" -Message "Creating or updating Terminology database on $($Config.sqlAddress)"
+    Write-DosMessage -Level "Information" -Message "Creating or updating Terminology database on $($Config.sqlAddress). This may take a few minutes"
     Publish-DosDacPac -TargetSqlInstance $Config.sqlAddress -DacPacFilePath $Dacpac -TargetDb "Terminology" -PublishOptionsFilePath $PublishProfile -ErrorAction Stop
 }
 


### PR DESCRIPTION
use common discovery service config from shared install.config
intelligently import required modules
better defaults and error handling
prompt that it may take a while on dacpac deploy