### PR TITLE
update installers to avoid prompting for an appPool password if the app was previously installed

### DIFF
--- a/Build/version.json
+++ b/Build/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.7",
+  "version": "1.0.8",
   "releaseComment": ""
 }


### PR DESCRIPTION
update installers to avoid prompting for an appPool password if the app was previously installed
update the installers to have a clearer password request prompt message